### PR TITLE
Feat/qr code dev

### DIFF
--- a/src/whatsapp/__tests__/events.service.spec.ts
+++ b/src/whatsapp/__tests__/events.service.spec.ts
@@ -107,25 +107,15 @@ describe('EventsService', () => {
     await mockClient.qrCallback?.('FAKE_QR_2');
     await mockClient.qrCallback?.('FAKE_QR_3');
 
+    const spyQr = jest.spyOn(emiteQrEventUseCase, 'execute');
     // Verifica se o useCase foi chamado para cada QR
-    expect(emiteQrEventUseCase.execute).toHaveBeenNthCalledWith(
-      1,
-      'FAKE_QR_1',
-      'TestClient',
-    );
-    expect(emiteQrEventUseCase.execute).toHaveBeenNthCalledWith(
-      2,
-      'FAKE_QR_2',
-      'TestClient',
-    );
-    expect(emiteQrEventUseCase.execute).toHaveBeenNthCalledWith(
-      3,
-      'FAKE_QR_3',
-      'TestClient',
-    );
+    expect(spyQr).toHaveBeenNthCalledWith(1, 'FAKE_QR_1', 'TestClient');
+    expect(spyQr).toHaveBeenNthCalledWith(2, 'FAKE_QR_2', 'TestClient');
+    expect(spyQr).toHaveBeenNthCalledWith(3, 'FAKE_QR_3', 'TestClient');
 
     // Verifica se o redis e destroy foram chamados após o terceiro QR
-    expect(redisService.deleteSession).toHaveBeenCalledWith('TestClient');
+    const deleteSessionSpy = jest.spyOn(redisService, 'deleteSession');
+    expect(deleteSessionSpy).toHaveBeenCalledWith('TestClient');
     expect(mockClient.destroy).toHaveBeenCalled();
   });
 
@@ -133,11 +123,13 @@ describe('EventsService', () => {
     // Simula que o limite não é atingido
     emiteQrEventUseCase.execute.mockResolvedValue(false);
 
+    const spyRedis = jest.spyOn(redisService, 'deleteSession');
+
     await service.registerAllEvents(mockClient as Client, 'TestClient');
 
     await mockClient.qrCallback?.('FAKE_QR_1');
 
-    expect(redisService.deleteSession).not.toHaveBeenCalled();
+    expect(spyRedis).not.toHaveBeenCalled();
     expect(mockClient.destroy).not.toHaveBeenCalled();
   });
 

--- a/src/whatsapp/__tests__/events.service.spec.ts
+++ b/src/whatsapp/__tests__/events.service.spec.ts
@@ -119,6 +119,8 @@ describe('EventsService', () => {
     expect(mockClient.destroy).toHaveBeenCalled();
   });
 
+  //ajustei aqui
+
   it('não deve destruir o client quando limite de QR não for atingido', async () => {
     // Simula que o limite não é atingido
     emiteQrEventUseCase.execute.mockResolvedValue(false);


### PR DESCRIPTION
- Implementado limite de 3 tentativas de QR Code por cliente utilizando Redis.
- Centralizada a lógica de controle de tentativas na UseCase `EmiteQrEventUseCase`.
- Ajustes no método `onQr` para delegar a execução à UseCase.
- Atualizados testes unitários para refletir o novo controle de limite.
- Implementado `spyOn` nos testes para resolver erros de `unbound-method`.
- Garantido que o ESLint não acuse warnings de Promises e tipos de retorno.
